### PR TITLE
Avoid appstream util network connections during builds

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -29,7 +29,7 @@ install_data('dev.tchx84.Portfolio.svg',
 appstream_util = find_program('appstream-util', required: false)
 if appstream_util.found()
   test('Validate appstream file', appstream_util,
-    args: ['validate', appstream_file]
+    args: ['validate', '--nonet', appstream_file]
   )
 endif
 


### PR DESCRIPTION
Default behavior of appstream util, while validating the appstream file, is to ensure that the URL referred to in the appstream file are reachable.
For downstream distribution (eg, in Debian), it is common practice that builds are network isolated and therefore this --nonet parameters helps with that requirement.