### PR TITLE
Install module files in the correct location

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,17 @@
+python = import('python')
+python_bin = python.find_installation('python3')
+python_dir = join_paths(get_option('prefix'), python_bin.get_install_dir())
+
 pkgdatadir = join_paths(get_option('prefix'), get_option('datadir'), meson.project_name())
-moduledir = join_paths(pkgdatadir, 'portfolio')
+moduledir = join_paths(python_dir, meson.project_name())
 gnome = import('gnome')
+
+conf = configuration_data()
+conf.set('PYTHON', python.find_installation('python3').path())
+conf.set('VERSION', meson.project_version())
+conf.set('localedir', join_paths(get_option('prefix'), get_option('localedir')))
+conf.set('pkgdatadir', pkgdatadir)
+
 
 gnome.compile_resources('portfolio',
   'portfolio.gresource.xml',
@@ -8,14 +19,6 @@ gnome.compile_resources('portfolio',
   install: true,
   install_dir: pkgdatadir,
 )
-
-python = import('python')
-
-conf = configuration_data()
-conf.set('PYTHON', python.find_installation('python3').path())
-conf.set('VERSION', meson.project_version())
-conf.set('localedir', join_paths(get_option('prefix'), get_option('localedir')))
-conf.set('pkgdatadir', pkgdatadir)
 
 configure_file(
   input: 'portfolio.in',

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,19 +6,18 @@ pkgdatadir = join_paths(get_option('prefix'), get_option('datadir'), meson.proje
 moduledir = join_paths(python_dir, meson.project_name())
 gnome = import('gnome')
 
-conf = configuration_data()
-conf.set('PYTHON', python.find_installation('python3').path())
-conf.set('VERSION', meson.project_version())
-conf.set('localedir', join_paths(get_option('prefix'), get_option('localedir')))
-conf.set('pkgdatadir', pkgdatadir)
-
-
 gnome.compile_resources('portfolio',
   'portfolio.gresource.xml',
   gresource_bundle: true,
   install: true,
   install_dir: pkgdatadir,
 )
+
+conf = configuration_data()
+conf.set('PYTHON', python.find_installation('python3').path())
+conf.set('VERSION', meson.project_version())
+conf.set('localedir', join_paths(get_option('prefix'), get_option('localedir')))
+conf.set('pkgdatadir', pkgdatadir)
 
 configure_file(
   input: 'portfolio.in',
@@ -32,9 +31,7 @@ portfolio_sources = [
   '__init__.py',
   'main.py',
   'window.py',
-  'row.py',
   'popup.py',
-  'placeholder.py',
   'worker.py',
   'places.py',
 ]


### PR DESCRIPTION
Helps meson install the module files where the system stores python
modules and not under /usr/share/portfolio/portfolio.