### PR TITLE
places: Add OS ROOT directory as System

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -94,6 +94,11 @@ scrolledwindow.frame {
     background: -gtk-icontheme("drive-removable-media-symbolic") left no-repeat;
     background-size: 16px;
 }
+.menu-box .places-box .menu-item.system label {
+    padding-left: 25px;
+    background: -gtk-icontheme("drive-harddisk-symbolic") left no-repeat;
+    background-size: 16px;
+}
 
 /* loading */
 


### PR DESCRIPTION
This will be OPTIONAL for the flatpak version, since
I prefer to give very few permissions by default. At
least until this app gets more testing in the wild.

If someone wants to enable this, use flatpak-override
or Flatseal, giving filesystem=host permission.