### PR TITLE
WIP: worker: Improve pasting behavior

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -34,6 +34,7 @@ portfolio_sources = [
   'popup.py',
   'worker.py',
   'places.py',
+  'utils.py',
 ]
 
 install_data(portfolio_sources, install_dir: moduledir)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,33 @@
+# utils.py
+#
+# Copyright 2020 Martin Abente Lahaye
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import re
+
+
+def find_new_name(directory, name):
+    counter = 1
+
+    while os.path.exists(os.path.join(directory, name)):
+        components = re.split("(\(\d+\)$)", name)
+        if len(components) > 1:
+            name = "".join(components[:-2])
+
+        name = f"{name}({counter})"
+        counter += 1
+
+    return name

--- a/src/window.py
+++ b/src/window.py
@@ -22,6 +22,7 @@ from locale import gettext as _
 
 from gi.repository import Gtk, GLib, Gio, Handy
 
+from . import utils
 from .popup import PortfolioPopup
 from .worker import PortfolioCutWorker
 from .worker import PortfolioCopyWorker
@@ -597,15 +598,9 @@ class PortfolioWindow(Handy.ApplicationWindow):
 
         self._update_all()
 
-    def _on_paste_updated(self, worker, index, total):
-        directory = self._history[self._index]
-        to_paste = self._to_copy if self._to_copy else self._to_cut
-        source_path = to_paste[index]
-
-        icon = self._find_icon(source_path)
-        name = os.path.basename(source_path)
-        path = os.path.join(directory, name)
-
+    def _on_paste_updated(self, worker, path, index, total):
+        icon = self._find_icon(path)
+        name = os.path.basename(path)
         self.liststore.append([icon, name, path])
 
         self.loading_bar.set_fraction((index + 1) / total)
@@ -659,7 +654,7 @@ class PortfolioWindow(Handy.ApplicationWindow):
 
         self._update_all()
 
-    def _on_delete_updated(self, worker, index, total):
+    def _on_delete_updated(self, worker, path, index, total):
         # XXX delete here instead of refreshing later
         self.loading_bar.set_fraction((index + 1) / total)
 
@@ -700,14 +695,7 @@ class PortfolioWindow(Handy.ApplicationWindow):
 
     def _on_new_folder(self, button):
         directory = self._history[self._index]
-
-        counter = 1
-        folder_name = _("New Folder")
-        while os.path.exists(os.path.join(directory, folder_name)):
-            folder_name = folder_name.split("(")[0]
-            folder_name = f"{folder_name}({counter})"
-            counter += 1
-
+        folder_name = utils.find_new_name(directory, _("New Folder"))
         path = os.path.join(directory, folder_name)
 
         try:


### PR DESCRIPTION
Pasting a source file or folder that already exists in the  target  directory will result in a renamed source file or folder.

e.g. If copying or moving a  "New Folder"  folder into a directory where another "New Folder" already exists, it will be pasted with "New Folder(1)" as its name.

This also fixes the issue where moving a directory would show up a file, the first time.