### PR TITLE
Show error message on dir listing error

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -177,6 +177,7 @@ class PortfolioLoadWorker(GObject.GObject):
         "started": (GObject.SignalFlags.RUN_LAST, None, (str,)),
         "updated": (GObject.SignalFlags.RUN_LAST, None, (str, object, int, int)),
         "finished": (GObject.SignalFlags.RUN_LAST, None, (str,)),
+        "failed": (GObject.SignalFlags.RUN_LAST, None, (str,)),
     }
 
     BUFFER = 75
@@ -188,7 +189,14 @@ class PortfolioLoadWorker(GObject.GObject):
 
     def start(self):
         self.emit("started", self._directory)
-        self._paths = os.listdir(self._directory)
+
+        try:
+            self._paths = os.listdir(self._directory)
+        except Exception as e:
+            logger.debug(e)
+            self.emit("failed", self._directory)
+            return
+
         self._total = len(self._paths)
         self._index = 0
         GLib.idle_add(self.step, priority=GLib.PRIORITY_HIGH_IDLE + 20)


### PR DESCRIPTION
In some cases the OS report directories that doesn't exists,
or the user don't have the required permissions to read them,
in that case the call to 'os.listdir()' will fail with an
OSError.

This commits add a new event to the PorfolioLoadWorker that
is fired if the directory can't be listed.

This new event is handled and a message with a summary
is displayed to the user.