### PR TITLE
worker: Catch permissions errors while walking directory

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -46,8 +46,11 @@ def count(path):
 def flatten_walk(path):
     _paths = []
 
+    def _callback(error):
+        raise error
+
     if os.path.isdir(path):
-        for directory, _, files in os.walk(path, topdown=False):
+        for directory, _, files in os.walk(path, topdown=False, onerror=_callback):
             for file in files:
                 _paths += [os.path.join(directory, file)]
             _paths += [directory]

--- a/src/window.py
+++ b/src/window.py
@@ -759,7 +759,7 @@ class PortfolioWindow(Handy.ApplicationWindow):
         self._worker.connect("failed", self._on_delete_failed)
         self._worker.start()
 
-    def _on_delete_started(self, worker, total):
+    def _on_delete_started(self, worker):
         self._busy = True
 
         self.loading_label.set_text(_("Deleting"))


### PR DESCRIPTION
Python  os.walk()  default behavior is to ignore permission errors, therefore, make sure we _do_ catch these errors and report these accordingly.