### PR TITLE
worker: Make delete feedback smoother

### DIFF
--- a/tests/window.py.in
+++ b/tests/window.py.in
@@ -1,6 +1,7 @@
 import os
 import sys
 import shutil
+import pytest
 
 ROOT_DIR = "@source_dir@"
 sys.path.append(ROOT_DIR)
@@ -168,14 +169,27 @@ def test_copy_paste():
     )
 
 
+@pytest.mark.timeout(5)
 def test_delete_all():
     # select all and delete, nothing should remain
     window._switch_to_selection_mode()
     window._select_all()
     window._on_delete_clicked(None)
+
     update_gtk()
+
     window._popup.confirm_button.emit("clicked")
-    window._worker.join()
+
+    finished = False
+    def _callback(worker, total):
+        nonlocal finished
+        finished = True
+
+    window._worker.connect("finished", _callback)
+
+    while not finished:
+        update_gtk()
+
     update_gtk()
 
     assert len(window.sorted) == 0
@@ -235,14 +249,27 @@ def test_rename():
     )
 
 
+@pytest.mark.timeout(5)
 def test_delete_one():
     # select "Renamed" folder and delete it
     window._switch_to_selection_mode()
     window._select_row(window.sorted[0].iter)
     window._on_delete_clicked(None)
+
     update_gtk()
+
     window._popup.confirm_button.emit("clicked")
-    window._worker.join()
+
+    finished = False
+    def _callback(worker, total):
+        nonlocal finished
+        finished = True
+
+    window._worker.connect("finished", _callback)
+
+    while not finished:
+        update_gtk()
+
     update_gtk()
 
     assert len(window.sorted) == 1

--- a/tests/worker.py.in
+++ b/tests/worker.py.in
@@ -195,7 +195,7 @@ def test_copy_worker_overwrite():
     assert os.path.exists(os.path.join(target, "folder"))
     assert os.path.exists(os.path.join(target, "file"))
 
-
+@pytest.mark.timeout(5)
 def test_delete_worker_default():
     from src.worker import PortfolioDeleteWorker
 
@@ -206,9 +206,17 @@ def test_delete_worker_default():
         (os.path.join(source, "file(1)"), None),
     ]
 
+    finished = False
+    def _callback(worker, total):
+        nonlocal finished
+        finished = True
+
     worker = PortfolioDeleteWorker(selection)
+    worker.connect("finished", _callback)
     worker.start()
-    worker.join()
+
+    while not finished:
+        update_gtk()
 
     assert len(os.listdir(source)) == 2
 


### PR DESCRIPTION
Keep the  delete operations in the  main  thread
so that the main thread doesn't get spammed with
signals from the worker thread.