### PR TITLE
worker: Support stopping paste and delete operations

### DIFF
--- a/src/window.ui
+++ b/src/window.ui
@@ -862,6 +862,36 @@
                             <property name="position">2</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkBox" id="stop_box">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <child>
+                              <object class="GtkButton" id="stop_button">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <child>
+                                  <object class="GtkImage">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="icon-name">media-playback-stop-symbolic</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="name">page3</property>
+                            <property name="title" translatable="yes">page3</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="position">0</property>
@@ -1039,6 +1069,21 @@
                             <property name="name">page2</property>
                             <property name="title">page2</property>
                             <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="stop_tools">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="name">page3</property>
+                            <property name="title" translatable="yes">page3</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                       </object>

--- a/tests/worker.py.in
+++ b/tests/worker.py.in
@@ -347,3 +347,101 @@ def test_open_worker_error():
         update_gtk()
 
     assert path == path_to_nowhere
+
+
+@pytest.mark.timeout(5)
+def test_copy_worker_stopped():
+    from src.worker import PortfolioCopyWorker
+
+    source = TEST_HOME_DIR
+    target = TEST_COPY_DIR
+
+    assert len(os.listdir(source)) == 5
+    assert len(os.listdir(target)) == 0
+
+    selection = [
+        (os.path.join(source, "folder"), None),
+        (os.path.join(source, "file"), None),
+    ]
+
+    stopped = False
+    def _callback(worker):
+        nonlocal stopped
+        stopped = True
+
+    worker = PortfolioCopyWorker(selection, target)
+    worker.connect("stopped", _callback)
+    worker.stop()
+    worker.start()
+    worker.join()
+
+    while not stopped:
+        update_gtk()
+
+    assert stopped is True
+    assert len(os.listdir(source)) == 5
+    assert len(os.listdir(target)) == 0
+
+
+@pytest.mark.timeout(5)
+def test_cut_worker_stopped():
+    from src.worker import PortfolioCutWorker
+
+    source = TEST_HOME_DIR
+    target = TEST_COPY_DIR
+
+    assert len(os.listdir(source)) == 5
+    assert len(os.listdir(target)) == 0
+
+    selection = [
+        (os.path.join(source, "folder"), None),
+        (os.path.join(source, "file"), None),
+    ]
+
+    stopped = False
+    def _callback(worker):
+        nonlocal stopped
+        stopped = True
+
+    worker = PortfolioCutWorker(selection, target)
+    worker.connect("stopped", _callback)
+    worker.stop()
+    worker.start()
+    worker.join()
+
+    while not stopped:
+        update_gtk()
+
+    assert stopped is True
+    assert len(os.listdir(source)) == 5
+    assert len(os.listdir(target)) == 0
+
+
+@pytest.mark.timeout(5)
+def test_delete_worker_stopped():
+    from src.worker import PortfolioDeleteWorker
+
+    source = TEST_HOME_DIR
+
+    assert len(os.listdir(source)) == 5
+
+    selection = [
+        (os.path.join(source, "copy"), None),
+        (os.path.join(source, "cut"), None),
+    ]
+
+    stopped = False
+    def _callback(worker):
+        nonlocal stopped
+        stopped = True
+
+    worker = PortfolioDeleteWorker(selection)
+    worker.connect("stopped", _callback)
+    worker.start()
+    worker.stop()
+
+    while not stopped:
+        update_gtk()
+
+    assert stopped is True
+    assert len(os.listdir(source)) == 5


### PR DESCRIPTION
This mimics the "cancel" behavior seen in other file managers, e.g. nautilus. All  "progress"  made until the stop button was hit is kept.