### PR TITLE
Set the argument to be used wrt supported MimeType

### DIFF
--- a/data/dev.tchx84.Portfolio.desktop.in
+++ b/data/dev.tchx84.Portfolio.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 # TRANSLATORS: Don't translate this text
 Name=Portfolio
-Exec=dev.tchx84.Portfolio
+Exec=dev.tchx84.Portfolio %f
 Terminal=false
 Type=Application
 Categories=Utility;


### PR DESCRIPTION
Specify how to execute the application including options  related to mimetype support. 
The MimeType attribute is set in the desktop file so using this %f option declares what argument should be used.

Freedesktop standard reference: https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables
Lintian warning raised on Debian side to identify this: https://lintian.debian.org/tags/desktop-mime-but-no-exec-code.html