### PR TITLE
window: Set the proper selection mode after switching places

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -333,6 +333,7 @@ class PortfolioWindow(Handy.ApplicationWindow):
         self._history = []
         self._index = -1
         self._move(path, False)
+        self._update_mode()
 
     def _refresh(self):
         self._move(self._history[self._index], True)


### PR DESCRIPTION
When selecting an item and then clicking on a Place, e.g. Home the next tapped item would select instead of activating.