### PR TITLE
Fall back to gettext module on systems that don't use glibc

### DIFF
--- a/src/dev.tchx84.Portfolio.in
+++ b/src/dev.tchx84.Portfolio.in
@@ -34,8 +34,8 @@ if __name__ == '__main__':
     resource = Gio.Resource.load(os.path.join(pkgdatadir, 'portfolio.gresource'))
     resource._register()
 
-    from portfolio.translation import translation_init
-    translation_init(localedir)
+    from portfolio import translation
+    translation.init(localedir)
 
     from portfolio import main
     sys.exit(main.main(VERSION))

--- a/src/dev.tchx84.Portfolio.in
+++ b/src/dev.tchx84.Portfolio.in
@@ -29,13 +29,13 @@ localedir = '@localedir@'
 sys.path.insert(1, pkgdatadir)
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-locale.bindtextdomain('portfolio', localedir)
-locale.textdomain('portfolio')
-
 if __name__ == '__main__':
     from gi.repository import Gio
     resource = Gio.Resource.load(os.path.join(pkgdatadir, 'portfolio.gresource'))
     resource._register()
+
+    from portfolio.translation import translation_init
+    translation_init(localedir)
 
     from portfolio import main
     sys.exit(main.main(VERSION))

--- a/src/meson.build
+++ b/src/meson.build
@@ -37,6 +37,7 @@ portfolio_sources = [
   'utils.py',
   'service.py',
   'place.py',
+  'translation.py',
 ]
 
 install_data(portfolio_sources, install_dir: moduledir)

--- a/src/places.py
+++ b/src/places.py
@@ -17,12 +17,11 @@
 
 import os
 
-from locale import gettext as _
-
 from gi.repository import GLib, Gio, Gtk, GObject, Handy
 
 from . import logger
 from .place import PortfolioPlace
+from .translation import gettext as _
 
 
 class PortfolioPlaces(Gtk.Stack):

--- a/src/translation.py
+++ b/src/translation.py
@@ -1,0 +1,21 @@
+import locale
+
+try:
+    from locale import gettext as _
+except ImportError:
+    from gettext import gettext as _
+
+
+def translation_init(localedir):
+    try:
+        locale.bindtextdomain("portfolio", localedir)
+        locale.textdomain("portfolio")
+    except AttributeError:
+        import gettext
+
+        gettext.bindtextdomain("portfolio", localedir)
+        gettext.textdomain("portfolio")
+
+
+def gettext(*args, **kwargs):
+    return _(*args, **kwargs)

--- a/src/translation.py
+++ b/src/translation.py
@@ -1,21 +1,39 @@
-import locale
+# translation.py
+#
+# Copyright 2021 Clayton Craft
+# Copyright 2021 Martin Abente Lahaye
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-try:
-    from locale import gettext as _
-except ImportError:
-    from gettext import gettext as _
+from . import logger
+
+gettext = lambda msg: msg
 
 
-def translation_init(localedir):
+def init(localedir):
+    global gettext
+
     try:
+        import locale
+
+        gettext = locale.gettext
         locale.bindtextdomain("portfolio", localedir)
         locale.textdomain("portfolio")
     except AttributeError:
-        import gettext
+        logger.debug("Using fallback gettext module")
+        import gettext as _gettext
 
-        gettext.bindtextdomain("portfolio", localedir)
-        gettext.textdomain("portfolio")
-
-
-def gettext(*args, **kwargs):
-    return _(*args, **kwargs)
+        gettext = _gettext.gettext
+        _gettext.bindtextdomain("portfolio", localedir)
+        _gettext.textdomain("portfolio")

--- a/src/window.py
+++ b/src/window.py
@@ -18,7 +18,8 @@
 import os
 
 from pathlib import Path
-from locale import gettext as _
+
+from .translation import gettext as _
 
 from gi.repository import Gtk, GLib, Gio, Handy, GObject
 

--- a/src/worker.py
+++ b/src/worker.py
@@ -21,11 +21,11 @@ import locale
 import datetime
 import threading
 
-from locale import gettext as _
 from gi.repository import Gio, GObject, GLib
 
 from . import utils
 from . import logger
+from .translation import gettext as _
 
 
 class WorkerStoppedException(Exception):


### PR DESCRIPTION
Python built without gettext support (from glibc) fail here, so this
falls back to importing the gettext python implementation
(https://github.com/hannosch/python-gettext), which might
be available.