### PR TITLE
popup: Don't close places popup automatically

### DIFF
--- a/src/popup.py
+++ b/src/popup.py
@@ -43,7 +43,7 @@ class PortfolioPopup(Gtk.Revealer):
         if on_cancel is not None:
             self.cancel_button.connect("clicked", on_cancel, self, data)
         else:
-            self.cancel_button.props.sensitive = False
+            self.cancel_button.connect("clicked", self._on_default_callback, self, data)
 
         if on_trash is not None:
             self.trash_button.connect("clicked", on_trash, self, data)
@@ -51,8 +51,6 @@ class PortfolioPopup(Gtk.Revealer):
             self.trash_button.props.visible = False
 
         if autoclose is True:
-            self.cancel_button.props.sensitive = True
-            self.cancel_button.connect("clicked", self._on_default_callback, self, data)
             GLib.timeout_add_seconds(
                 DEFAULT_CLOSE_TIME, self._on_default_callback, None, None, None
             )

--- a/src/window.py
+++ b/src/window.py
@@ -481,7 +481,7 @@ class PortfolioWindow(Handy.ApplicationWindow):
         if self._places_popup is not None:
             self._places_popup.destroy()
 
-        self._places_popup = PortfolioPopup(description, None, None, None, True, None)
+        self._places_popup = PortfolioPopup(description, None, None, None, False, None)
         self.places_popup_box.add(self._places_popup)
         self._places_popup.props.reveal_child = True
 


### PR DESCRIPTION
If removing the device takes long,  it's likely that
the user won't stay looking at the popup transitions
so  it's better for the popup  to stay open for when
the user comes back.