### PR TITLE
utils: Add sync_folder and sync all folder creation

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -86,6 +86,12 @@ def is_flatpak():
     return os.path.exists(os.path.join(os.path.sep, ".flatpak-info"))
 
 
+def sync_folder(path):
+    fd = os.open(path, os.O_DIRECTORY)
+    os.fsync(fd)
+    os.close(fd)
+
+
 def find_mount_point(path):
     path = os.path.abspath(path)
     while not os.path.ismount(path):

--- a/src/window.py
+++ b/src/window.py
@@ -1180,6 +1180,7 @@ class PortfolioWindow(Handy.ApplicationWindow):
 
         try:
             Path(path).mkdir(parents=False, exist_ok=True)
+            utils.sync_folder(path)
         except Exception as e:
             logger.debug(e)
             self._notify(

--- a/src/worker.py
+++ b/src/worker.py
@@ -149,6 +149,7 @@ class PortfolioCopyWorker(PortfolioWorker):
             with open(destination_path, "wb") as destination:
                 self._do_copy(source, destination, callback)
 
+        utils.sync_folder(os.path.dirname(destination_path))
         shutil.copymode(source_path, destination_path)
 
         self._count += 1


### PR DESCRIPTION
Calling fsync() does not necessarily ensure that the entry in the
directory containing the file has also reached disk.  For that an
explicit fsync() on a file descriptor for the directory is also
needed.