### PR TITLE
utils: Add sync_folder and sync all folder creation

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -86,6 +86,12 @@ def is_flatpak():
     return os.path.exists(os.path.join(os.path.sep, ".flatpak-info"))
 
 
+def sync_folder(path):
+    fd = os.open(path, os.O_DIRECTORY)
+    os.fsync(fd)
+    os.close(fd)
+
+
 def find_mount_point(path):
     path = os.path.abspath(path)
     while not os.path.ismount(path):

--- a/src/worker.py
+++ b/src/worker.py
@@ -186,6 +186,8 @@ class PortfolioCopyWorker(PortfolioWorker):
                 logger.debug(e)
                 self.emit("failed", destination)
                 return
+            finally:
+                utils.sync_folder(os.path.dirname(destination))
 
         self.emit("finished", self._total)
 
@@ -222,6 +224,8 @@ class PortfolioCutWorker(PortfolioCopyWorker):
                 logger.debug(e)
                 self.emit("failed", path)
                 return
+            finally:
+                utils.sync_folder(os.path.dirname(destination))
 
         self.emit("finished", self._total)
 


### PR DESCRIPTION
Calling fsync() does not necessarily ensure that the entry in the
directory containing the file has also reached disk.  For that an
explicit fsync() on a file descriptor for the directory is also
needed.