### PR TITLE
worker: Update view only after paste operation

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -406,8 +406,8 @@ class PortfolioWindow(Handy.ApplicationWindow):
 
         self._worker = Worker(to_paste, directory)
         self._worker.connect("started", self._on_paste_started)
-        self._worker.connect("pre-update", self._on_paste_pre_updated)
         self._worker.connect("updated", self._on_paste_updated)
+        self._worker.connect("post-update", self._on_paste_post_updated)
         self._worker.connect("finished", self._on_paste_finished)
         self._worker.connect("failed", self._on_paste_failed)
         self._worker.connect("stopped", self._on_paste_stopped)
@@ -1027,8 +1027,11 @@ class PortfolioWindow(Handy.ApplicationWindow):
         self.action_stack.set_visible_child(self.stop_box)
         self.tools_stack.set_visible_child(self.stop_tools)
 
-    def _on_paste_pre_updated(self, worker, path, overwritten):
+    def _on_paste_post_updated(self, worker, path, overwritten):
         if overwritten:
+            return
+        if not os.path.exists(path):
+            logger.debug(f"Attempting to add unexisting {path}")
             return
 
         # XXX this approach won't allow me to put stat info in liststore

--- a/src/worker.py
+++ b/src/worker.py
@@ -72,8 +72,8 @@ class PortfolioCopyWorker(PortfolioWorker):
 
     __gsignals__ = {
         "started": (GObject.SignalFlags.RUN_LAST, None, (int,)),
-        "pre-update": (GObject.SignalFlags.RUN_LAST, None, (str, bool)),
         "updated": (GObject.SignalFlags.RUN_LAST, None, (str, int, int, float, float)),
+        "post-update": (GObject.SignalFlags.RUN_LAST, None, (str, bool)),
         "finished": (GObject.SignalFlags.RUN_LAST, None, (int,)),
         "failed": (GObject.SignalFlags.RUN_LAST, None, (str,)),
         "stopped": (GObject.SignalFlags.RUN_LAST, None, ()),
@@ -171,7 +171,6 @@ class PortfolioCopyWorker(PortfolioWorker):
 
             try:
                 self._stop_check()
-                self.emit("pre-update", destination, overwritten)
 
                 if os.path.isdir(path):
                     if overwritten and os.path.isdir(path):
@@ -186,8 +185,9 @@ class PortfolioCopyWorker(PortfolioWorker):
                 logger.debug(e)
                 self.emit("failed", destination)
                 return
-            finally:
+            else:
                 utils.sync_folder(os.path.dirname(destination))
+                self.emit("post-update", destination, overwritten)
 
         self.emit("finished", self._total)
 
@@ -208,7 +208,6 @@ class PortfolioCutWorker(PortfolioCopyWorker):
 
             try:
                 self._stop_check()
-                self.emit("pre-update", destination, overwritten)
 
                 if destination == path:
                     continue
@@ -224,8 +223,9 @@ class PortfolioCutWorker(PortfolioCopyWorker):
                 logger.debug(e)
                 self.emit("failed", path)
                 return
-            finally:
+            else:
                 utils.sync_folder(os.path.dirname(destination))
+                self.emit("post-update", destination, overwritten)
 
         self.emit("finished", self._total)
 


### PR DESCRIPTION
Previously, files were added to the view before the
actual  paste  operation ocurred.  If the operation
failed, the view would end up with ghost files.