### PR TITLE
Construct URI in order to handle special characters

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -381,7 +381,16 @@ class PortfolioOpenWorker(GObject.GObject):
     def start(self):
         self.emit("started")
 
-        uri = f"file://{self._path}"
+        uri = GLib.Uri.build(
+            GLib.UriFlags.NONE,
+            "file",
+            None,
+            None,
+            -1,
+            self._path,
+            None,
+            None
+        ).to_string()
         Gio.AppInfo.launch_default_for_uri_async(
             uri, None, None, self._on_launch_finished, None
         )


### PR DESCRIPTION
Fixes #267. Constructing a URI using a library function handles special characters.