### PR TITLE
window: follow GNOME dark style preference changes

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -142,6 +142,8 @@ class PortfolioWindow(Handy.ApplicationWindow):
 
     def _setup(self):
         Handy.init()
+        Handy.StyleManager.get_default().set_color_scheme(
+            Handy.ColorScheme.PREFER_LIGHT)
 
         self._popup = None
         self._places_popup = None


### PR DESCRIPTION
Use libhandy's StyleManager to follow the dark mode variant used by libadwaita and GTK4 apps through gsettings
org.gnome.desktop.interface.color-scheme key. This allows the app to change its style based on a standard and documented property that can be changed through, e.g: GNOME Settings toggle in Appearance panel. Current behavior is to follow the gtk-application-prefer-dark-theme key in ~/.config/gtk-3.0/settings.ini file, which is deprecated and as far as I am aware, undocumented.

Related https://gitlab.gnome.org/GNOME/Initiatives/-/issues/32