### PR TITLE
worker: Move icon-loading step to the worker thread

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -785,8 +785,7 @@ class PortfolioWindow(Handy.ApplicationWindow):
         return GLib.SOURCE_REMOVE
 
     def _on_load_updated(self, worker, directory, found, index, total):
-        for name, path in found:
-            icon = utils.get_file_icon(path)
+        for name, path, icon in found:
             row = self.liststore.append([icon, name, path])
 
             if self._to_select == path:
@@ -1064,16 +1063,13 @@ class PortfolioWindow(Handy.ApplicationWindow):
         self.action_stack.set_visible_child(self.stop_box)
         self.tools_stack.set_visible_child(self.stop_tools)
 
-    def _on_paste_post_updated(self, worker, path, overwritten):
+    def _on_paste_post_updated(self, worker, name, path, icon, overwritten):
         if overwritten:
             return
         if not os.path.exists(path):
             logger.debug(f"Attempting to add unexisting {path}")
             return
 
-        # XXX this approach won't allow me to put stat info in liststore
-        name = os.path.basename(path)
-        icon = utils.get_file_icon(path)
         self.liststore.append([icon, name, path])
 
     def _on_paste_updated(self, worker, path, index, total, current_bytes, total_bytes):

--- a/src/worker.py
+++ b/src/worker.py
@@ -77,7 +77,7 @@ class PortfolioCopyWorker(PortfolioWorker):
     __gsignals__ = {
         "started": (GObject.SignalFlags.RUN_LAST, None, (int,)),
         "updated": (GObject.SignalFlags.RUN_LAST, None, (str, int, int, float, float)),
-        "post-update": (GObject.SignalFlags.RUN_LAST, None, (str, bool)),
+        "post-update": (GObject.SignalFlags.RUN_LAST, None, (str, str, object, bool)),
         "finished": (GObject.SignalFlags.RUN_LAST, None, (int,)),
         "failed": (GObject.SignalFlags.RUN_LAST, None, (str,)),
         "stopped": (GObject.SignalFlags.RUN_LAST, None, ()),
@@ -191,7 +191,13 @@ class PortfolioCopyWorker(PortfolioWorker):
                 return
             else:
                 utils.sync_folder(os.path.dirname(destination))
-                self.emit("post-update", destination, overwritten)
+                self.emit(
+                    "post-update",
+                    os.path.basename(destination),
+                    destination,
+                    utils.get_file_icon(destination),
+                    overwritten,
+                )
 
         self.emit("finished", self._total)
 
@@ -229,7 +235,13 @@ class PortfolioCutWorker(PortfolioCopyWorker):
                 return
             else:
                 utils.sync_folder(os.path.dirname(destination))
-                self.emit("post-update", destination, overwritten)
+                self.emit(
+                    "post-update",
+                    os.path.basename(destination),
+                    destination,
+                    utils.get_file_icon(destination),
+                    overwritten,
+                )
 
         self.emit("finished", self._total)
 
@@ -351,7 +363,7 @@ class PortfolioLoadWorker(GObject.GObject, CachedWorker):
                 if not self._hidden and name.startswith("."):
                     continue
                 path = os.path.join(self._directory, name)
-                found.append((name, path))
+                found.append((name, path, utils.get_file_icon(path)))
 
         self._index += self.BUFFER
         self.emit("updated", self._directory, found, self._index, self._total)

--- a/tests/worker.py.in
+++ b/tests/worker.py.in
@@ -90,7 +90,7 @@ def test_load_worker_default():
 
     def _callback(worker, directory, found, index, total):
         nonlocal paths
-        paths += [path for name, path in found]
+        paths += [path for name, path, icon in found]
 
     worker = PortfolioLoadWorker(TEST_HOME_DIR)
     worker.connect("updated", _callback)
@@ -115,7 +115,7 @@ def test_load_worker_hidden():
 
     def _callback(worker, directory, found, index, total):
         nonlocal paths
-        paths += [path for name, path in found]
+        paths += [path for name, path, icon in found]
 
     worker = PortfolioLoadWorker(TEST_HOME_DIR, True)
     worker.connect("updated", _callback)


### PR DESCRIPTION
This was being done on the UI thread, which causes some unncessary freezes.