### PR TITLE
worker: Fix loading files in trash

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -827,9 +827,10 @@ class PortfolioLoadTrashWorker(GObject.GObject, CachedWorker):
 
         path = self._paths[self._index]
         name = os.path.basename(path)
+        icon = utils.get_file_icon(path)
 
         self._index += 1
-        self.emit("updated", "", [(name, path)], self._index, self._total)
+        self.emit("updated", "", [(name, path, icon)], self._index, self._total)
         self._timeout_handler_id = GLib.idle_add(
             self.step, priority=GLib.PRIORITY_HIGH_IDLE + 20
         )

--- a/tests/worker.py.in
+++ b/tests/worker.py.in
@@ -522,7 +522,7 @@ def test_load_trash_worker_default():
 
     def _update_callback(worker, name, tuples, index, total):
         nonlocal paths
-        paths += [path for name, path in tuples]
+        paths += [path for name, path, icon in tuples]
 
     finished = False
 


### PR DESCRIPTION
Trash worker also needs to load icons on the worker thread instead of the UI thread.