### PR TITLE
metainfo: Add device-specific metadata

### DIFF
--- a/data/dev.tchx84.Portfolio.metainfo.xml.in
+++ b/data/dev.tchx84.Portfolio.metainfo.xml.in
@@ -48,6 +48,10 @@
   <url type="bugtracker">https://github.com/tchx84/Portfolio/issues</url>
   <url type="vcs-browser">https://github.com/tchx84/Portfolio</url>
   <url type="translate">https://github.com/tchx84/Portfolio/tree/master/po</url>
+  <requires>
+    <control>touch</control>
+    <display_length compare="ge">360</display_length>
+  </requires>
   <custom>
     <value key="Purism::form_factor">mobile</value>
   </custom>


### PR DESCRIPTION
Thank you, @tchx84, for creating this very helpful app!

This PR will (after a subsequent release) make Portfolio show up in Flathub's Mobile Collection: https://flathub.org/en/apps/collection/mobile/1

See https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/\#mobile-only-apps for  information regarding the change. 

> Mobile only apps
>
>Mobile and tablet only apps typically should have:
>
```
<requires>
  <control>touch</control>
  <display_length compare="le">1279</display_length>
</requires>
```
>
>Desktop and mobile apps
>
>Apps that support and work on mobile, tablet and desktop typically should have:
>
```
<recommends>
  <control>keyboard</control>
  <control>pointing</control>
  <control>touch</control>
</recommends>
<requires>
  <display_length compare="ge">360</display_length>
</requires>
```

I chose mobile-only as 

>     <value key="Purism::form_factor">mobile</value>

suggests that this is most fitting.